### PR TITLE
修正 windows 下路径合成格式错误的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ function followPath(path) {
 }
 
 function createPath (dirname) {
-  var relaPath = path.join('/', path.relative(moduleRoot, dirname));
+  var relaPath = path.join('/', path.relative(moduleRoot, dirname)).replace(/\\/g, '/');
 
   var modulePath = relaPath.split('/node_modules/');
   var root = 'root@' + componentsInfo.version;


### PR DESCRIPTION
windows下使用会报错
[ERROR] Cannot read property 'split' of undefined in

原因是由于windows下文件路径的问题
createPath 中 relaPath.split('/node_modules/') 没有返回正确的结果
