### PR TITLE
输入错误导致报错，文件/index.js:528

### DIFF
--- a/index.js
+++ b/index.js
@@ -522,7 +522,7 @@ var entry = module.exports = function (fis, opts) {
 
   fis.on('release:start', onReleaseStart.bind(null, fis, opts));
   fis.on('lookup:file', onFileLookUp);
-  fis.on('proccess:start', onPreprocess);
+  fis.on('process:start', onPreprocess);
 
   fis.set('component.type', 'node_modules');
 };


### PR DESCRIPTION
错误代码位置`/index.js:528`，具体如下：

``` js
fis.on('proccess:start', onPreprocess);
```

错误原因：
`proccess`应为`process`，否则交由FIS处理时，会提示[WARIN]错误，如下为FIS处理代码，`./lib/fis.js:86`

``` js
if (arguments[0].match(/^proccess\:/)) {
  arguments[0] = 'process:' + arguments[0].slice(9)
  fis.log.warning('Did you mean ' + arguments[0] + ' event?')
}
```
