### PR TITLE
找不到文件可以交由其他hook去查找，而不应该error停止

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,7 +498,11 @@ function onFileLookUp (info, file) {
       filePath = path.join(file.dirname, rest);
     }
     else {
-      filePath = resolve.sync(rest, {basedir: moduleRoot})
+      try {
+        filePath = resolve.sync(rest, {basedir: moduleRoot})
+      } catch (e) {
+        fis.log.warning(e.message)
+      }
     }
 
     if (!filePath) {


### PR DESCRIPTION
在使用fis过程中，有些团队会自定义一些hook来定制模块化require方式，当使用了这个hook时，filePath = resolve.sync(rest, {basedir: moduleRoot})这行代码会导致找不到文件但没有捕获异常而导致程序终止，其他自定义的hook也会不执行，这里一出错就直接停止是不对的，可以交由其他hook去分析文件依赖
