### PR TITLE
修复 ignoreDevDependencies 为 true 时判断可能报错的问题

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -57,7 +57,9 @@ function collectPkgs(npmDir) {
         fs.readdirSync(currentDir).forEach(function(folderName) {
             if (
                 folderName[0] === '.' ||
-                opts.ignoreDevDependencies && hostJson.devDependencies && hostJson.devDependencies[folderName] && !hostJson.dependencies[folderName]
+                opts.ignoreDevDependencies && hostJson.devDependencies && hostJson.devDependencies[folderName] && (
+                    !hostJson.dependencies || !hostJson.dependencies[folderName]
+                )
             ) {
                 return null;
             }
@@ -68,7 +70,9 @@ function collectPkgs(npmDir) {
 
                     if (
                         subfolder[0] === '.' ||
-                        opts.ignoreDevDependencies && hostJson.devDependencies && hostJson.devDependencies[pkgname] && !hostJson.dependencies[pkgname]
+                        opts.ignoreDevDependencies && hostJson.devDependencies && hostJson.devDependencies[pkgname] && (
+                            !hostJson.dependencies || !hostJson.dependencies[pkgname]
+                        )
                     ) {
                         return null;
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fis3-hook-node_modules",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "fis3 npm support",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
修复 ignoreDevDependencies 为 true 时判断可能报错的问题。

有的 package.json 里可能没有 dependencies 字段。